### PR TITLE
koopa bounce fix 4/13

### DIFF
--- a/SprintZero/Collisions/EnemyPlayerCollision.cs
+++ b/SprintZero/Collisions/EnemyPlayerCollision.cs
@@ -17,13 +17,21 @@ namespace EnemyPlayerCollision
             {
                 if (currentMario.Falling && currentMario.MarioCollider.Bottom <= currentEnemy.EnemyCollider.Center.Y + 10)
                 {
-                    currentEnemy.Stomped();
-                    currentMario.Bounce();
+                    if (currentEnemy is Koopa koopa && (koopa.KoopaState == Koopa.KoopaStates.ShellStill || koopa.KoopaState == Koopa.KoopaStates.ShellStill2))
+                    {
+                        bool kickRight = currentMario.MarioCollider.Center.X < koopa.EnemyCollider.Center.X;
+                        koopa.Kicked(kickRight);
+                    }
+                    else
+                    {
+                        currentEnemy.Stomped();
+                    }
 
+                    currentMario.Bounce();
                 }
                 else
                 {
-                    if (currentEnemy is Koopa koopa && koopa.KoopaState == Koopa.KoopaStates.ShellStill)
+                    if (currentEnemy is Koopa koopa && (koopa.KoopaState == Koopa.KoopaStates.ShellStill || koopa.KoopaState == Koopa.KoopaStates.ShellStill2))
                     {
                         bool kickRight = currentMario.MarioCollider.Center.X < koopa.EnemyCollider.Center.X;
                         koopa.Kicked(kickRight);

--- a/SprintZero/Content/obj/DesktopGL/net10.0/Content/.mgstats
+++ b/SprintZero/Content/obj/DesktopGL/net10.0/Content/.mgstats
@@ -1,5 +1,5 @@
 Source File,Dest File,Processor Type,Content Type,Source File Size,Dest File Size,Build Seconds
-"C:/Users/adamt/source/repos/3902-Project/SprintZero/Content/Font/File.spritefont","C:/Users/adamt/source/repos/3902-Project/SprintZero/Content/bin/DesktopGL/Content/Font/File.xnb","FontDescriptionProcessor","SpriteFontContent",2065,37913,0.169436
+"C:/Users/adamt/source/repos/3902-Project/SprintZero/Content/Font/File.spritefont","C:/Users/adamt/source/repos/3902-Project/SprintZero/Content/bin/DesktopGL/Content/Font/File.xnb","FontDescriptionProcessor","SpriteFontContent",2065,37913,0.1690019
 "C:/Users/adamt/source/repos/3902-Project/SprintZero/Content/Images/goombasprites.png","C:/Users/adamt/source/repos/3902-Project/SprintZero/Content/bin/DesktopGL/Content/Images/goombasprites.xnb","TextureProcessor","Texture2DContent",653,9365,0.0100344
 "C:/Users/adamt/source/repos/3902-Project/SprintZero/Content/Images/items.png","C:/Users/adamt/source/repos/3902-Project/SprintZero/Content/bin/DesktopGL/Content/Images/items.xnb","TextureProcessor","Texture2DContent",1882,118645,0.0099762
 "C:/Users/adamt/source/repos/3902-Project/SprintZero/Content/Images/koopaSprites.png","C:/Users/adamt/source/repos/3902-Project/SprintZero/Content/bin/DesktopGL/Content/Images/koopaSprites.xnb","TextureProcessor","Texture2DContent",1203,18517,0.003035

--- a/SprintZero/Content/obj/DesktopGL/net10.0/Content/Font/File.mgcontent
+++ b/SprintZero/Content/obj/DesktopGL/net10.0/Content/Font/File.mgcontent
@@ -3,7 +3,7 @@
   <SourceFile>C:/Users/adamt/source/repos/3902-Project/SprintZero/Content/Font/File.spritefont</SourceFile>
   <SourceTime>2026-04-06T13:45:38.0717675-04:00</SourceTime>
   <DestFile>C:/Users/adamt/source/repos/3902-Project/SprintZero/Content/bin/DesktopGL/Content/Font/File.xnb</DestFile>
-  <DestTime>2026-04-12T23:27:15.3564525-04:00</DestTime>
+  <DestTime>2026-04-13T05:18:20.1425-04:00</DestTime>
   <Importer>FontDescriptionImporter</Importer>
   <ImporterTime>2025-10-20T10:25:32-04:00</ImporterTime>
   <Processor>FontDescriptionProcessor</Processor>


### PR DESCRIPTION
Koopa shells now get kicked when Mario bounces on them